### PR TITLE
optimize release binary size

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,4 +11,3 @@ resolver = "2"
 [profile.release]
 debug = 0  # upstream has '2' for some reason
 lto = true  # reduces bin size; also slows link-time, but we don't build often
-strip = true  # automatically strip symbols from the binary.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,4 +9,6 @@ members = [
 resolver = "2"
 
 [profile.release]
-debug = 2
+debug = 0  # upstream has '2' for some reason
+lto = true  # reduces bin size; also slows link-time, but we don't build often
+strip = true  # automatically strip symbols from the binary.


### PR DESCRIPTION
## Description of change

These changes reduce `target/release/mount-s3` from 132.41 MiB to 0.99 MiB!! 

That seems too good to be true. 

I followed https://github.com/johnthagen/min-sized-rust, and neither of `lto` and `strip` should change application behavior. 

Odd that `aws-labs` upstream sets `debug = 2` on their release builds??? (https://doc.rust-lang.org/cargo/reference/profiles.html#debug)

Relevant issues: <!-- Please add issue numbers. -->

## Does this change impact existing behavior?

None of these options should change binary performance or behavior.