### PR TITLE
Retry HTTP 429 responses as throttling errors

### DIFF
--- a/mountpoint-s3-client/src/s3_crt_client.rs
+++ b/mountpoint-s3-client/src/s3_crt_client.rs
@@ -1414,6 +1414,11 @@ fn try_parse_generic_error(request_result: &MetaRequestResult) -> Option<S3Reque
         // redirect
         400 => try_parse_forbidden(request_result).or_else(|| try_parse_redirect(request_result)),
         403 => try_parse_forbidden(request_result),
+        // HTTP 429 is the standard rate-limiting status code. S3-compatible
+        // backends like Cloudflare R2 return 429 for bandwidth throttling
+        // instead of S3's usual 503 SlowDown. Treat it identically so the CRT
+        // retry strategy can back off and retry.
+        429 => Some(S3RequestError::Throttled),
         // if the http response status is not set, we look into crt_error_code to identify the error
         0 => try_parse_throttled(request_result)
             .or_else(|| try_parse_canceled_request(request_result))
@@ -1875,6 +1880,18 @@ mod tests {
             panic!("wrong result, got: {result:?}");
         };
         assert_eq!(message, "This error is made up.");
+    }
+
+    #[test]
+    fn parse_429_throttled() {
+        // Cloudflare R2 returns HTTP 429 with ServiceUnavailable for bandwidth throttling
+        let body = br#"<?xml version="1.0" encoding="UTF-8"?><Error><Code>ServiceUnavailable</Code><Message>You have exceeded your available bandwidth limit.</Message></Error>"#;
+        let result = make_result(429, OsStr::from_bytes(&body[..]), None);
+        let result = try_parse_generic_error(&result);
+        assert!(
+            matches!(result, Some(S3RequestError::Throttled)),
+            "expected Throttled, got: {result:?}",
+        );
     }
 
     fn make_crt_error_result(response_status: i32, crt_error: Error) -> MetaRequestResult {


### PR DESCRIPTION
**Context:** This came out of me following up synthetic monitoring failures. https://modal-com.slack.com/archives/C083KB8GMMJ/p1776893214071649?thread_ts=1772790076.682459&cid=C083KB8GMMJ

---

S3-compatible backends like Cloudflare R2 return HTTP 429 for bandwidth throttling instead of S3's native 503 SlowDown response. The CRT retry logic is keyed on `AWS_ERROR_S3_SLOW_DOWN` (which maps to 503), so `try_parse_throttled` never matches for 429. The 429 falls through to `_ => None` in `try_parse_generic_error`, becomes a terminal `ResponseError`, and the mount dies with EIO after a single failed attempt.

This adds a `429` arm to the `try_parse_generic_error` match that returns `S3RequestError::Throttled`, enabling the existing exponential backoff retry strategy (up to 10 attempts, 500ms base with full jitter) for these responses.

Observed in production when a Modal `CloudBucketMount` backed by R2 failed immediately on the first `GetObject` with: `"You have exceeded your available bandwidth limit."` (HTTP 429, `<Code>ServiceUnavailable</Code>`).

### Does this change impact existing behavior?

Yes — HTTP 429 responses that were previously treated as terminal errors are now retried. This is the correct behavior: 429 is the standard rate-limiting status code and should be retryable. No other response codes are affected.

### Does this change need a changelog entry? Does it require a version change?

Not required — this is a Modal fork-only change for R2 compatibility, not an upstream contribution.

### Key review items

- The 429 arm unconditionally returns `Throttled` without parsing the response body (unlike the 400/403 arms which inspect XML error codes). This is intentional since 429 unambiguously means rate-limiting regardless of the body content, but worth confirming this assumption holds.
- `S3RequestError::Throttled` reports HTTP 503 in its `ClientErrorMetadata`. The actual 429 status code is not preserved in the error metadata — this shouldn't affect retry behavior but may matter for logging/metrics.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).

Link to Devin session: https://modal.devinenterprise.com/sessions/1742473af31243ae8ce6830f659271eb
Requested by: @thundergolfer