### PR TITLE
Retry HTTP 429 responses as throttling errors

### DIFF
--- a/mountpoint-s3-client/src/s3_crt_client.rs
+++ b/mountpoint-s3-client/src/s3_crt_client.rs
@@ -1424,10 +1424,7 @@ fn try_parse_generic_error(request_result: &MetaRequestResult) -> Option<S3Reque
                 .as_ref()
                 .and_then(|body| xmltree::Element::parse(body.as_bytes()).ok())
                 .map(|root| {
-                    let code = root
-                        .get_child("Code")
-                        .and_then(|e| e.get_text())
-                        .map(|s| s.to_string());
+                    let code = root.get_child("Code").and_then(|e| e.get_text()).map(|s| s.to_string());
                     let message = root
                         .get_child("Message")
                         .and_then(|e| e.get_text())

--- a/mountpoint-s3-client/src/s3_crt_client.rs
+++ b/mountpoint-s3-client/src/s3_crt_client.rs
@@ -1414,6 +1414,11 @@ fn try_parse_generic_error(request_result: &MetaRequestResult) -> Option<S3Reque
         // redirect
         400 => try_parse_forbidden(request_result).or_else(|| try_parse_redirect(request_result)),
         403 => try_parse_forbidden(request_result),
+        // HTTP 429 is the standard rate-limiting status code. S3-compatible
+        // backends like Cloudflare R2 return 429 for bandwidth throttling
+        // instead of S3's usual 503 SlowDown. Treat it identically so the CRT
+        // retry strategy can back off and retry.
+        429 => Some(S3RequestError::Throttled),
         // if the http response status is not set, we look into crt_error_code to identify the error
         0 => try_parse_throttled(request_result)
             .or_else(|| try_parse_canceled_request(request_result))
@@ -1875,6 +1880,18 @@ mod tests {
             panic!("wrong result, got: {result:?}");
         };
         assert_eq!(message, "This error is made up.");
+    }
+
+    #[test]
+    fn parse_429_throttled() {
+        // Cloudflare R2 returns HTTP 429 with ServiceUnavailable for bandwidth throttling
+        let body = br#"<?xml version="1.0" encoding="UTF-8"?><Error><Code>ServiceUnavailable</Code><Message>You have exceeded your available bandwidth limit.</Message></Error>"#;
+        let result = make_result(429, OsStr::from_bytes(&body[..]), None);
+        let result = try_parse_generic_error(&result);
+        assert!(
+            matches!(result, Some(S3RequestError::Throttled)),
+            "expected Throttled, got: {result:?}",
+        );
     }
 
     fn make_crt_error_result(response_status: i32, crt_error: Error) -> MetaRequestResult {

--- a/mountpoint-s3-client/src/s3_crt_client.rs
+++ b/mountpoint-s3-client/src/s3_crt_client.rs
@@ -1200,7 +1200,7 @@ pub enum S3RequestError {
 
     /// The request was throttled by S3
     #[error("Request throttled")]
-    Throttled,
+    Throttled(ClientErrorMetadata),
 
     /// Cannot fetch more data because current read window is exhausted. The read window must
     /// be advanced using [GetObjectRequest::increment_read_window(u64)] to continue fetching
@@ -1224,11 +1224,7 @@ impl ProvideErrorMetadata for S3RequestError {
         match self {
             Self::ResponseError(request_result) => ClientErrorMetadata::from_meta_request_result(request_result),
             Self::Forbidden(_, metadata) => metadata.clone(),
-            Self::Throttled => ClientErrorMetadata {
-                http_code: Some(503),
-                error_code: Some("SlowDown".to_string()),
-                error_message: Some("Please reduce your request rate.".to_string()),
-            },
+            Self::Throttled(metadata) => metadata.clone(),
             Self::IncorrectRegion(_, metadata) => metadata.clone(),
             _ => Default::default(),
         }
@@ -1397,7 +1393,11 @@ fn try_parse_generic_error(request_result: &MetaRequestResult) -> Option<S3Reque
     fn try_parse_throttled(request_result: &MetaRequestResult) -> Option<S3RequestError> {
         let crt_error_code = request_result.crt_error.raw_error();
         if crt_error_code == mountpoint_s3_crt::s3::ErrorCode::AWS_ERROR_S3_SLOW_DOWN as i32 {
-            Some(S3RequestError::Throttled)
+            Some(S3RequestError::Throttled(ClientErrorMetadata {
+                http_code: Some(503),
+                error_code: Some("SlowDown".to_string()),
+                error_message: Some("Please reduce your request rate.".to_string()),
+            }))
         } else {
             None
         }
@@ -1418,7 +1418,29 @@ fn try_parse_generic_error(request_result: &MetaRequestResult) -> Option<S3Reque
         // backends like Cloudflare R2 return 429 for bandwidth throttling
         // instead of S3's usual 503 SlowDown. Treat it identically so the CRT
         // retry strategy can back off and retry.
-        429 => Some(S3RequestError::Throttled),
+        429 => {
+            let (error_code, error_message) = request_result
+                .error_response_body
+                .as_ref()
+                .and_then(|body| xmltree::Element::parse(body.as_bytes()).ok())
+                .map(|root| {
+                    let code = root
+                        .get_child("Code")
+                        .and_then(|e| e.get_text())
+                        .map(|s| s.to_string());
+                    let message = root
+                        .get_child("Message")
+                        .and_then(|e| e.get_text())
+                        .map(|s| s.to_string());
+                    (code, message)
+                })
+                .unwrap_or((None, None));
+            Some(S3RequestError::Throttled(ClientErrorMetadata {
+                http_code: Some(429),
+                error_code,
+                error_message,
+            }))
+        }
         // if the http response status is not set, we look into crt_error_code to identify the error
         0 => try_parse_throttled(request_result)
             .or_else(|| try_parse_canceled_request(request_result))
@@ -1888,9 +1910,14 @@ mod tests {
         let body = br#"<?xml version="1.0" encoding="UTF-8"?><Error><Code>ServiceUnavailable</Code><Message>You have exceeded your available bandwidth limit.</Message></Error>"#;
         let result = make_result(429, OsStr::from_bytes(&body[..]), None);
         let result = try_parse_generic_error(&result);
-        assert!(
-            matches!(result, Some(S3RequestError::Throttled)),
-            "expected Throttled, got: {result:?}",
+        let Some(S3RequestError::Throttled(metadata)) = result else {
+            panic!("expected Throttled, got: {result:?}");
+        };
+        assert_eq!(metadata.http_code, Some(429));
+        assert_eq!(metadata.error_code.as_deref(), Some("ServiceUnavailable"));
+        assert_eq!(
+            metadata.error_message.as_deref(),
+            Some("You have exceeded your available bandwidth limit."),
         );
     }
 


### PR DESCRIPTION
S3-compatible backends like Cloudflare R2 return HTTP 429 for bandwidth throttling instead of S3's native 503 SlowDown response. The CRT retry logic is keyed on `AWS_ERROR_S3_SLOW_DOWN` (which maps to 503), so `try_parse_throttled` never matches for 429. The 429 falls through to `_ => None` in `try_parse_generic_error`, becomes a terminal `ResponseError`, and the FUSE mount dies with EIO.

This adds a `429` arm to the `try_parse_generic_error` match that returns `S3RequestError::Throttled(...)`, enabling the existing exponential backoff retry strategy (up to 10 attempts, 500ms base with full jitter) for these responses. The 429 arm parses the XML response body to extract the actual error code and message, so error metadata accurately reflects the real response (HTTP 429 / `ServiceUnavailable`) rather than hardcoding 503 / `SlowDown`.

To support this, `S3RequestError::Throttled` was changed from a unit variant to `Throttled(ClientErrorMetadata)`. The existing CRT-error path (`AWS_ERROR_S3_SLOW_DOWN`, i.e. S3's 503 SlowDown) continues to populate the metadata with the same synthetic 503/SlowDown values as before.

Observed in production when a Modal `CloudBucketMount` backed by R2 failed immediately on the first `GetObject` with: `"You have exceeded your available bandwidth limit."` (HTTP 429, `<Code>ServiceUnavailable</Code>`).

### Does this change impact existing behavior?

Yes — HTTP 429 responses that were previously treated as terminal errors are now retried. No other response codes are affected. The `Throttled` variant is now a tuple variant carrying `ClientErrorMetadata`, which is a breaking change to the enum shape but does not affect runtime behavior for the existing 503 path (same metadata values are produced).

### Does this change need a changelog entry? Does it require a version change?

Not required — this is a Modal fork-only change for R2 compatibility, not an upstream contribution.

### Human review checklist

- The 429 arm parses the XML body best-effort (falls back to `None` for error code/message if parsing fails). Confirm this is acceptable vs. providing a generic fallback message.
- The `Throttled` variant is now `Throttled(ClientErrorMetadata)` — any downstream code pattern-matching on `Throttled` will need updating. Only `s3_crt_client.rs` matches on it within this repo.
- This was validated with a unit test using a synthetic R2 response, not against a live R2 endpoint.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).

Link to Devin session: https://modal.devinenterprise.com/sessions/1742473af31243ae8ce6830f659271eb
Requested by: @thundergolfer